### PR TITLE
set `CARGO_NET_GIT_FETCH_WITH_CLI` for dbt formula using v0.4.0 of dbt-extractor

### DIFF
--- a/Formula/dbt-bigquery.rb
+++ b/Formula/dbt-bigquery.rb
@@ -296,6 +296,7 @@ class DbtBigquery < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt-bigquery@1.0.0-b1.rb
+++ b/Formula/dbt-bigquery@1.0.0-b1.rb
@@ -285,6 +285,7 @@ class DbtBigqueryAT100B1 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt-bigquery@1.0.0-rc2.rb
+++ b/Formula/dbt-bigquery@1.0.0-rc2.rb
@@ -295,6 +295,7 @@ class DbtBigqueryAT100Rc2 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt-bigquery@1.0.0.rb
+++ b/Formula/dbt-bigquery@1.0.0.rb
@@ -296,6 +296,7 @@ class DbtBigqueryAT100 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt-development.rb
+++ b/Formula/dbt-development.rb
@@ -345,6 +345,7 @@ class DbtDevelopment < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
 
     res = resources.map(&:name).to_set

--- a/Formula/dbt-postgres.rb
+++ b/Formula/dbt-postgres.rb
@@ -226,6 +226,7 @@ class DbtPostgres < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt-postgres@1.0.0-b1.rb
+++ b/Formula/dbt-postgres@1.0.0-b1.rb
@@ -215,6 +215,7 @@ class DbtPostgresAT100B1 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt-postgres@1.0.0-rc2.rb
+++ b/Formula/dbt-postgres@1.0.0-rc2.rb
@@ -226,6 +226,7 @@ class DbtPostgresAT100Rc2 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt-postgres@1.0.0.rb
+++ b/Formula/dbt-postgres@1.0.0.rb
@@ -226,6 +226,7 @@ class DbtPostgresAT100 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt-postgres@1.0.1.rb
+++ b/Formula/dbt-postgres@1.0.1.rb
@@ -226,6 +226,7 @@ class DbtPostgresAT101 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt-redshift.rb
+++ b/Formula/dbt-redshift.rb
@@ -252,6 +252,7 @@ class DbtRedshift < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt-redshift@1.0.0-b1.rb
+++ b/Formula/dbt-redshift@1.0.0-b1.rb
@@ -245,6 +245,7 @@ class DbtRedshiftAT100B1 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt-redshift@1.0.0-rc2.rb
+++ b/Formula/dbt-redshift@1.0.0-rc2.rb
@@ -251,6 +251,7 @@ class DbtRedshiftAT100Rc2 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt-redshift@1.0.0.rb
+++ b/Formula/dbt-redshift@1.0.0.rb
@@ -252,6 +252,7 @@ class DbtRedshiftAT100 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt-snowflake.rb
+++ b/Formula/dbt-snowflake.rb
@@ -271,6 +271,7 @@ class DbtSnowflake < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt-snowflake@1.0.0-b1.rb
+++ b/Formula/dbt-snowflake@1.0.0-b1.rb
@@ -320,6 +320,7 @@ class DbtSnowflakeAT100B1 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt-snowflake@1.0.0-rc2.rb
+++ b/Formula/dbt-snowflake@1.0.0-rc2.rb
@@ -270,6 +270,7 @@ class DbtSnowflakeAT100Rc2 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt-snowflake@1.0.0.rb
+++ b/Formula/dbt-snowflake@1.0.0.rb
@@ -271,6 +271,7 @@ class DbtSnowflakeAT100 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt.rb
+++ b/Formula/dbt.rb
@@ -414,6 +414,7 @@ class Dbt < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt@0.21.0-b1.rb
+++ b/Formula/dbt@0.21.0-b1.rb
@@ -414,6 +414,7 @@ class DbtAT0210B1 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt@0.21.0-b2.rb
+++ b/Formula/dbt@0.21.0-b2.rb
@@ -414,6 +414,7 @@ class DbtAT0210B2 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt@0.21.0-rc1.rb
+++ b/Formula/dbt@0.21.0-rc1.rb
@@ -414,6 +414,7 @@ class DbtAT0210Rc1 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt@0.21.0-rc2.rb
+++ b/Formula/dbt@0.21.0-rc2.rb
@@ -414,6 +414,7 @@ class DbtAT0210Rc2 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt@0.21.0.rb
+++ b/Formula/dbt@0.21.0.rb
@@ -414,6 +414,7 @@ class DbtAT0210 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt@0.21.1-rc1.rb
+++ b/Formula/dbt@0.21.1-rc1.rb
@@ -414,6 +414,7 @@ class DbtAT0211Rc1 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt@0.21.1-rc2.rb
+++ b/Formula/dbt@0.21.1-rc2.rb
@@ -414,6 +414,7 @@ class DbtAT0211Rc2 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"

--- a/Formula/dbt@0.21.1.rb
+++ b/Formula/dbt@0.21.1.rb
@@ -414,6 +414,7 @@ class DbtAT0211 < Formula
   end
 
   def install
+    ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"


### PR DESCRIPTION
helps resolve #49 

This env var tell cargo to use native git client when installing dbt-extractor from source instead of the git client built into cargo ([docs](https://doc.rust-lang.org/cargo/reference/config.html#netgit-fetch-with-cli)). I've only applied this change to formula that depend on dbt-extractor v0.4.0 which uses an unsupported git protocol to install a dependency.