### PR TITLE
add back dbt-snowflake hacks

### DIFF
--- a/.github/formula-template.j2
+++ b/.github/formula-template.j2
@@ -20,7 +20,31 @@ class {{ classname }} < Formula
 
   def install
     ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
+{%- if package != 'dbt-snowflake' %}
     virtualenv_install_with_resources
+{% else %}
+    venv = virtualenv_create(libexec, "python3")
+    venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
+      "--upgrade", "pip"
+
+    resources.each do |r|
+      if r.name == "snowflake-connector-python"
+        # workaround for installing `snowflake-connector-python`
+        # package w/o build-system deps (e.g. pyarrow)
+        # adds the `--no-use-pep517` parameter
+        r.stage do
+          venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
+            "-v", "--no-deps", "--no-binary", ":all:", "--ignore-installed", "--no-use-pep517", Pathname.pwd
+        end
+      else
+        venv.pip_install r
+      end
+    end
+
+    venv.pip_install_and_link buildpath
+
+    bin.install_symlink "#{libexec}/bin/dbt" => "dbt"
+{%- endif %}
   end
 
   test do

--- a/.github/formula-template.j2
+++ b/.github/formula-template.j2
@@ -20,13 +20,15 @@ class {{ classname }} < Formula
 
   def install
     ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
-{%- if package != 'dbt-snowflake' %}
-    virtualenv_install_with_resources
-{% else %}
     venv = virtualenv_create(libexec, "python3")
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/pip", "install",
       "--upgrade", "pip"
 
+{%- if package != 'dbt-snowflake' %}
+    resources.each do |r|
+      venv.pip_install r
+    end
+{% else %}
     resources.each do |r|
       if r.name == "snowflake-connector-python"
         # workaround for installing `snowflake-connector-python`
@@ -40,11 +42,11 @@ class {{ classname }} < Formula
         venv.pip_install r
       end
     end
+{%- endif %}
 
     venv.pip_install_and_link buildpath
 
     bin.install_symlink "#{libexec}/bin/dbt" => "dbt"
-{%- endif %}
   end
 
   test do


### PR DESCRIPTION
### Description

resolves error when install dbt-snowflake formula, this installs `snowflake-connector-python` without `pyarrow` as a build dependency. We don't use the `pandas` functionality of `snowflake-connector-python` so this doesn't affect functionality.

```
==> /usr/local/Cellar/dbt-snowflake/1.0.1/libexec/bin/pip install -v --no-deps --no-binary :all: --ignore-installed /private/tmp/dbt-snowflake--snowflake-connector-python-20220421-26995-6jqz9t/snowflake-connector-python-2.7.6
Last 15 lines from /Users/kwigley/Library/Logs/Homebrew/dbt-snowflake/47.pip:
  × pip subprocess to install build dependencies did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  full command: /usr/local/Cellar/dbt-snowflake/1.0.1/libexec/bin/python3.9 /private/tmp/pip-standalone-pip-xkcpdqdd/__env_pip__.zip/pip install --ignore-installed --no-user --prefix /private/tmp/pip-build-env-13g6mahf/overlay --no-warn-script-location --no-binary :all: --only-binary :none: -i https://pypi.org/simple -- 'setuptools>=40.6.0' wheel cython 'pyarrow>=6.0.0,<6.1.0'
  cwd: [inherit]
  Installing build dependencies: finished with status 'error'
error: subprocess-exited-with-error

× pip subprocess to install build dependencies did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
-->

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
