### PR TITLE
replace existing symbolic links

### DIFF
--- a/.github/example.event.json
+++ b/.github/example.event.json
@@ -1,8 +1,8 @@
 {
   "action": "workflow_dispatch",
   "inputs": {
-    "version": "1.0.1",
-    "dbt-package": "dbt-snowflake",
+    "version": "1.0.6",
+    "dbt-package": "dbt-postgres",
     "is-default-version": "true"
   }
 }

--- a/.github/workflows/formula.yml
+++ b/.github/workflows/formula.yml
@@ -153,7 +153,7 @@ jobs:
         run: |
           mkdir -p Aliases
           cd Aliases
-          ln -s ../${{ steps.gen-filename.outputs.filename }} ${{ github.event.inputs.dbt-package }}@${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}
+          ln -sf ../${{ steps.gen-filename.outputs.filename }} ${{ github.event.inputs.dbt-package }}@${{ steps.semver.outputs.major }}.${{ steps.semver.outputs.minor }}
 
       - name: Format default formula file
         if: ${{ !env.ACT && fromJson(github.event.inputs.is-default-version) }}


### PR DESCRIPTION
resolves issue seen here https://github.com/dbt-labs/homebrew-dbt/runs/6201782696?check_suite_focus=true

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
-->

### Description
When replacing symbolic link when creating a homebrew alias (which is apparently now required when you use `brew audit`) use `-f` to replace the existing sym link. Tested this locally with success.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
