### PR TITLE
Fix brew file length error

### DIFF
--- a/.github/formula-template.j2
+++ b/.github/formula-template.j2
@@ -21,8 +21,8 @@ class {{ classname }} < Formula
   def install
     ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
     venv = virtualenv_create(libexec, "python3")
-    venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python", "-m", "pip", "install",
-      "pip==22.0.4"
+    venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",
+       "-m", "pip", "install", "pip==22.0.4"
 
 {%- if package != 'dbt-snowflake' %}
     resources.each do |r|


### PR DESCRIPTION
### Description
We are seeing the GitHub Action to build new formulas fail due to the brew style guidelines being broken with a line being too long in the formula. This is just to fix the line length and spills more arguments to the next line. This has passed the style guidelines when testing locally.

Failed Action example:
https://github.com/dbt-labs/homebrew-dbt/runs/7094732981?check_suite_focus=true#step:17:134

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
