### PR TITLE
Fix deprecated GitHub action commands

### DIFF
--- a/.github/workflows/formula.yml
+++ b/.github/workflows/formula.yml
@@ -96,7 +96,7 @@ jobs:
           if [ ${{ steps.semver.outputs.is-pre-release }} == 1 ]
           then
             echo "This is a prelease"
-            echo filename-with-version="Formula/${{ github.event.inputs.dbt-package }}@${{ steps.semver.outputs.base-version }}-${{ steps.semver.outputs.pre-release }}.rb" >> $GITHUB_OUTPUT
+            FILENAME_WITH_VERSION="Formula/${{ github.event.inputs.dbt-package }}@${{ steps.semver.outputs.base-version }}-${{ steps.semver.outputs.pre-release }}.rb"
           else
             echo "This is a final release"
             FILENAME_WITH_VERSION="Formula/${{ github.event.inputs.dbt-package }}@${{ steps.semver.outputs.version }}.rb"

--- a/.github/workflows/formula.yml
+++ b/.github/workflows/formula.yml
@@ -101,7 +101,9 @@ jobs:
             echo "This is a final release"
             FILENAME_WITH_VERSION="Formula/${{ github.event.inputs.dbt-package }}@${{ steps.semver.outputs.version }}.rb"
           fi
-          echo filename="Formula/${{ github.event.inputs.dbt-package }}.rb" >> $GITHUB_OUTPUT
+          echo "filename-with-version=${FILENAME_WITH_VERSION}" >> $GITHUB_OUTPUT
+          FILENAME="Formula/${{ github.event.inputs.dbt-package }}.rb"
+          echo "filename=${FILENAME}" >> $GITHUB_OUTPUT
 
       - name: Generate formula class name
         id: gen-classname

--- a/.github/workflows/formula.yml
+++ b/.github/workflows/formula.yml
@@ -88,7 +88,7 @@ jobs:
           RESOURCES_FILE_PATH=$BUILD_DIR/resources.txt
           poet -r ${{ github.event.inputs.dbt-package }} | .github/process-python-resources.py ${{ github.event.inputs.dbt-package }} > "$RESOURCES_FILE_PATH"
           cat "$RESOURCES_FILE_PATH"
-          echo ::set-output name=formula-resources-file::"$RESOURCES_FILE_PATH"
+          echo "formula-resources-file=${RESOURCES_FILE_PATH}" >> $GITHUB_OUTPUT
 
       - name: Generate formula file name
         id: gen-filename
@@ -96,20 +96,20 @@ jobs:
           if [ ${{ steps.semver.outputs.is-pre-release }} == 1 ]
           then
             echo "This is a prelease"
-            echo ::set-output name=filename-with-version::"Formula/${{ github.event.inputs.dbt-package }}@${{ steps.semver.outputs.base-version }}-${{ steps.semver.outputs.pre-release }}.rb"
+            echo filename-with-version="Formula/${{ github.event.inputs.dbt-package }}@${{ steps.semver.outputs.base-version }}-${{ steps.semver.outputs.pre-release }}.rb" >> $GITHUB_OUTPUT
           else
             echo "This is a final release"
-            echo ::set-output name=filename-with-version::"Formula/${{ github.event.inputs.dbt-package }}@${{ steps.semver.outputs.version }}.rb"
+            echo filename-with-version="Formula/${{ github.event.inputs.dbt-package }}@${{ steps.semver.outputs.version }}.rb" >> $GITHUB_OUTPUT
           fi
-          echo ::set-output name=filename::"Formula/${{ github.event.inputs.dbt-package }}.rb"
+          echo filename="Formula/${{ github.event.inputs.dbt-package }}.rb" >> $GITHUB_OUTPUT
 
       - name: Generate formula class name
         id: gen-classname
         run: |
           PACKAGE_NAME=$(python -c "print(''.join(word.title() for word in '${{ github.event.inputs.dbt-package }}'.split('-')))")
           PACKAGE_VERSION=$(python -c "print(''.join(word.title() for word in '${{ steps.semver.outputs.version }}'.split('.')))")
-          echo ::set-output name=classname-with-version::${PACKAGE_NAME}AT${PACKAGE_VERSION}
-          echo ::set-output name=classname::${PACKAGE_NAME}
+          echo "classname-with-version=${PACKAGE_NAME}AT${PACKAGE_VERSION}" >> $GITHUB_OUTPUT
+          echo "classname=${PACKAGE_NAME}" >> $GITHUB_OUTPUT
 
       - name: Generate versioned formula file
         env:

--- a/.github/workflows/formula.yml
+++ b/.github/workflows/formula.yml
@@ -99,7 +99,7 @@ jobs:
             echo filename-with-version="Formula/${{ github.event.inputs.dbt-package }}@${{ steps.semver.outputs.base-version }}-${{ steps.semver.outputs.pre-release }}.rb" >> $GITHUB_OUTPUT
           else
             echo "This is a final release"
-            echo filename-with-version="Formula/${{ github.event.inputs.dbt-package }}@${{ steps.semver.outputs.version }}.rb" >> $GITHUB_OUTPUT
+            FILENAME_WITH_VERSION="Formula/${{ github.event.inputs.dbt-package }}@${{ steps.semver.outputs.version }}.rb"
           fi
           echo filename="Formula/${{ github.event.inputs.dbt-package }}.rb" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/installation-tests.yml
+++ b/.github/workflows/installation-tests.yml
@@ -1,6 +1,6 @@
 # **what?**
 # This workflow installs the latest version of each dbt adapter from homebrew.
-# It then run 'dbt --version' to verify the installation was successful.
+# It then runs 'dbt --version' to verify the installation was successful.
 # If it fails for the scheduled runs, it will post to our team alerts channel.
 
 # **why?**

--- a/.github/workflows/installation-tests.yml
+++ b/.github/workflows/installation-tests.yml
@@ -1,11 +1,11 @@
 # **what?**
 # This workflow installs the latest version of each dbt adapter from homebrew.
-# It then run 'dbt --version' to verify the installation was successful. 
+# It then run 'dbt --version' to verify the installation was successful.
 # If it fails for the scheduled runs, it will post to our team alerts channel.
 
 # **why?**
 # This is a simple way to test all adapter installations at a single
-# time. It allows us to test them on a schedule as well to check for 
+# time. It allows us to test them on a schedule as well to check for
 # any breaking dependency changes that might happen and alert us on it.
 
 # **when?**
@@ -16,23 +16,23 @@ name: Homebrew installation testing
 
 on:
   workflow_dispatch:
-  
+
   # run this once per night to ensure no regressions
   schedule:
-    - cron: '0 9,13,18 * * *' # 9:00, 13:00, 18:00 UTC
+    - cron: "0 9,13,18 * * *" # 9:00, 13:00, 18:00 UTC
 
 # no permissions are needed for this workflow
 permissions: {}
 
 jobs:
   homebrew:
-    
     strategy:
       fail-fast: false
       matrix:
-        adapter: ['dbt-postgres', 'dbt-redshift', 'dbt-snowflake', 'dbt-bigquery']
+        adapter:
+          ["dbt-postgres", "dbt-redshift", "dbt-snowflake", "dbt-bigquery"]
         os: [macos-latest]
-        
+
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -42,11 +42,11 @@ jobs:
           brew install git
           brew tap dbt-labs/dbt
           brew install --verbose ${{ matrix.adapter }}
-          
+
       - name: Verify ${{ matrix.adapter }} version
         run: |
           dbt --version
-          
+
   post-failure:
     runs-on: ubuntu-latest
     needs: homebrew
@@ -57,7 +57,7 @@ jobs:
         uses: ravsamhq/notify-slack-action@v1
         if: ${{ github.event_name == 'schedule' }}
         with:
-          notification_title: 'Homebrew nightly integration test failed'
+          notification_title: "Homebrew nightly integration test failed"
           status: ${{ job.status }}
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_DEV_CORE_ALERTS }}


### PR DESCRIPTION
resolves #186 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
-->

### Description

As communicated by Github in https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ these commands should be replaced.


### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
