### PR TITLE
use python 3.10

### DIFF
--- a/.github/workflows/formula.yml
+++ b/.github/workflows/formula.yml
@@ -58,7 +58,9 @@ jobs:
         uses: Homebrew/actions/setup-homebrew@master
 
       - name: Setup python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
+        with: 
+          python-version: "3.10"
 
       - name: Create build dir
         run: mkdir -p $BUILD_DIR


### PR DESCRIPTION
### Description

pyarrow (specifically for `dbt-snowflake`) does not support python 3.11 yet so we need to pin to python 3.10.

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
