### PR TITLE
update used gh actions ahead of set-output, node12 deprecation

### DIFF
--- a/.github/workflows/formula.yml
+++ b/.github/workflows/formula.yml
@@ -51,7 +51,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup homebrew
         if: ${{ !env.ACT }}
@@ -59,7 +59,7 @@ jobs:
 
       - name: Setup python
         uses: actions/setup-python@v4
-        with: 
+        with:
           python-version: "3.10"
 
       - name: Create build dir
@@ -177,7 +177,7 @@ jobs:
 
       - name: Create pull request
         if: ${{ !env.ACT }}
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5
         with:
           title: "${{ github.event.inputs.dbt-package }} formula for version ${{ github.event.inputs.version }}"
           branch: "${{ github.event.inputs.dbt-package }}-formula/${{ github.event.inputs.version }}"

--- a/.github/workflows/installation-tests.yml
+++ b/.github/workflows/installation-tests.yml
@@ -35,7 +35,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      
+
       - name: "Prepare Brew"
         # brew upgrade generates some symlink update warnings that cause failures without the || true.
         # They're just that the symlink wasn't updated which is okay to ignore.
@@ -44,10 +44,10 @@ jobs:
         run: |
           brew update
           brew upgrade || true
-      
+
       - name: "Check installed"
         run: brew list
-      
+
       - name: "Brew Tap"
         run: |
           brew tap dbt-labs/dbt
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Posting scheduled run failures
-        uses: ravsamhq/notify-slack-action@v1
+        uses: ravsamhq/notify-slack-action@v2
         if: ${{ github.event_name == 'schedule' }}
         with:
           notification_title: "Homebrew nightly integration test failed"

--- a/.github/workflows/jira-creation.yml
+++ b/.github/workflows/jira-creation.yml
@@ -19,9 +19,7 @@ permissions:
 
 jobs:
   jira-issue-creation:
-    uses: dbt-labs/actions/.github/workflows/jira-creation.yml@v1
-    with:
-      project_key: "CT"
+    uses: dbt-labs/actions/.github/workflows/jira-creation-actions.yml@v1
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/jira-label.yml
+++ b/.github/workflows/jira-label.yml
@@ -19,9 +19,7 @@ permissions:
 
 jobs:
   jira-label:
-    uses: dbt-labs/actions/.github/workflows/jira-label.yml@v1
-    with:
-      project_key: "CT"
+    uses: dbt-labs/actions/.github/workflows/jira-label-actions.yml@v1
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}

--- a/.github/workflows/jira-transition.yml
+++ b/.github/workflows/jira-transition.yml
@@ -17,9 +17,7 @@ on:
 
 jobs:
   jira-transition:
-    uses: dbt-labs/actions/.github/workflows/jira-transition.yml@v1
-    with:
-      project_key: "CT"
+    uses: dbt-labs/actions/.github/workflows/jira-transition-actions.yml@v1
     secrets:
       JIRA_BASE_URL: ${{ secrets.JIRA_BASE_URL }}
       JIRA_USER_EMAIL: ${{ secrets.JIRA_USER_EMAIL }}


### PR DESCRIPTION
resolves #288 

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
-->

### Description

Update versions of used Github Actions ahead of:

[node12 deprecation](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) (Summer 2023)
[set-output deprecation](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) (fully disabled on 31st May 2023)
<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
