### PR TITLE
update used gh actions ahead of node12 deprecation

### DIFF
--- a/.github/workflows/formula.yml
+++ b/.github/workflows/formula.yml
@@ -51,7 +51,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup homebrew
         if: ${{ !env.ACT }}
@@ -177,7 +177,7 @@ jobs:
 
       - name: Create pull request
         if: ${{ !env.ACT }}
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v5
         with:
           title: "${{ github.event.inputs.dbt-package }} formula for version ${{ github.event.inputs.version }}"
           branch: "${{ github.event.inputs.dbt-package }}-formula/${{ github.event.inputs.version }}"

--- a/.github/workflows/installation-tests.yml
+++ b/.github/workflows/installation-tests.yml
@@ -67,7 +67,7 @@ jobs:
 
     steps:
       - name: Posting scheduled run failures
-        uses: ravsamhq/notify-slack-action@v1
+        uses: ravsamhq/notify-slack-action@v2
         if: ${{ github.event_name == 'schedule' }}
         with:
           notification_title: "Homebrew nightly integration test failed"


### PR DESCRIPTION
Please merge this update today! [node 12 support dropping tomorrow](https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/) and these version updates to Github Actions get ahead of that. Resolves RELENG-144