### PR TITLE
remove audit step from formula.yml

### DIFF
--- a/.github/workflows/formula.yml
+++ b/.github/workflows/formula.yml
@@ -159,14 +159,6 @@ jobs:
         run: |
           brew style --formula --fix "${{ steps.gen-filename.outputs.filename }}"
 
-      - name: Audit default formula file
-        if: ${{ !env.ACT && fromJson(github.event.inputs.is-default-version) }}
-        # check everything except `audit_file` checks for now, this currently fails because of how
-        # homebrew enforces aliases
-        # (https://github.com/Homebrew/brew/blob/80e5327013c4eba4b60e2fccdc8df2762048757b/Library/Homebrew/formula_auditor.rb#L53-L125)
-        run: |
-          brew audit --formula --new --except file "${{ steps.gen-filename.outputs.filename }}"
-
       - name: Create pull request
         if: ${{ !env.ACT }}
         uses: peter-evans/create-pull-request@v5

--- a/.github/workflows/formula.yml
+++ b/.github/workflows/formula.yml
@@ -140,14 +140,6 @@ jobs:
         run: |
           brew style --formula --fix "${{ steps.gen-filename.outputs.filename-with-version }}"
 
-      - name: Audit versioned formula file
-        if: ${{ !env.ACT }}
-        # check everything except `audit_file` checks for now, this currently fails because of how
-        # homebrew enforces aliases
-        # (https://github.com/Homebrew/brew/blob/80e5327013c4eba4b60e2fccdc8df2762048757b/Library/Homebrew/formula_auditor.rb#L53-L125)
-        run: |
-          brew audit --formula --new --except file "${{ steps.gen-filename.outputs.filename-with-version }}"
-
       - name: Generate default formula file
         if: ${{ fromJson(github.event.inputs.is-default-version) }}
         env:


### PR DESCRIPTION
Audit step is currently broken as homebrew has changed the interface, as it's not really needed since we manage our own tap it's simpler to just remove it.

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
-->

### Description

<!---
  Describe the Pull Request here. Add any references and info to help reviewers
  understand your changes. Include any tradeoffs you considered.
-->

### Checklist

- [ ] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [ ] This PR includes tests, or tests are not required/relevant for this PR
