### PR TITLE
Include pip in the venv

### DIFF
--- a/.github/formula-template.j2
+++ b/.github/formula-template.j2
@@ -20,7 +20,7 @@ class {{ classname }} < Formula
 
   def install
     ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
-    venv = virtualenv_create(libexec, "python3", system_site_packages: false)
+    venv = virtualenv_create(libexec, "python3", system_site_packages: false, without_pip: false)
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",
        "-m", "pip", "install", "pip==22.3.1"
 

--- a/Formula/dbt-bigquery@1.5.3.rb
+++ b/Formula/dbt-bigquery@1.5.3.rb
@@ -312,7 +312,7 @@ class DbtBigqueryAT153 < Formula
 
   def install
     ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
-    venv = virtualenv_create(libexec, "python3", system_site_packages: false)
+    venv = virtualenv_create(libexec, "python3", system_site_packages: false, without_pip: false)
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",
        "-m", "pip", "install", "pip==22.3.1"
     resources.each do |r|

--- a/Formula/dbt-postgres@1.5.4.rb
+++ b/Formula/dbt-postgres@1.5.4.rb
@@ -233,7 +233,7 @@ class DbtPostgresAT154 < Formula
 
   def install
     ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
-    venv = virtualenv_create(libexec, "python3", system_site_packages: false)
+    venv = virtualenv_create(libexec, "python3", system_site_packages: false, without_pip: false)
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",
        "-m", "pip", "install", "pip==22.3.1"
     resources.each do |r|

--- a/Formula/dbt-redshift@1.4.0.rb
+++ b/Formula/dbt-redshift@1.4.0.rb
@@ -278,7 +278,7 @@ class DbtRedshiftAT140 < Formula
 
   def install
     ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
-    venv = virtualenv_create(libexec, "python3", system_site_packages: false)
+    venv = virtualenv_create(libexec, "python3", system_site_packages: false, without_pip: false)
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",
        "-m", "pip", "install", "pip==22.3.1"
     resources.each do |r|

--- a/Formula/dbt-snowflake@1.5.2.rb
+++ b/Formula/dbt-snowflake@1.5.2.rb
@@ -307,7 +307,7 @@ class DbtSnowflakeAT152 < Formula
 
   def install
     ENV["CARGO_NET_GIT_FETCH_WITH_CLI"] = "true"
-    venv = virtualenv_create(libexec, "python3", system_site_packages: false)
+    venv = virtualenv_create(libexec, "python3", system_site_packages: false, without_pip: false)
     venv.instance_variable_get(:@formula).system venv.instance_variable_get(:@venv_root)/"bin/python",
        "-m", "pip", "install", "pip==22.3.1"
     resources.each do |r|


### PR DESCRIPTION
### Description

`brew install` is throwing the following error on the most recent installs:

```
==> Installing dbt-labs/dbt/dbt-bigquery
/usr/bin/env tar --extract --no-same-owner --file /Users/runner/Library/Caches/Homebrew/downloads/93a088c3f3fdbba442dea7cee60f1c6898a33c75abfef31618753c6aa58960fd--dbt-bigquery-1.5.3.tar.gz --directory /private/tmp/d20230807-9341-1mx6ia
/usr/bin/env cp -pR /private/tmp/d20230807-9341-1mx6ia/dbt-bigquery-1.5.3/. /private/tmp/dbt-bigquery-20230807-9341-uswxm0/dbt-bigquery-1.5.3
==> python3 -m venv --without-pip /usr/local/Cellar/dbt-bigquery/1.5.3/libexec
==> /usr/local/Cellar/dbt-bigquery/1.5.3/libexec/bin/python -m pip install pip==22.3.1
/usr/local/Cellar/dbt-bigquery/1.5.3/libexec/bin/python: No module named pip
```

The default for installing `pip` in the virtual environment is `False`. I've updated this to `True`.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
