### PR TITLE
ADAP-753: Manually add url and sha256 for redshift-connector 2.0.913

### DIFF
--- a/.github/process-python-resources.py
+++ b/.github/process-python-resources.py
@@ -2,25 +2,65 @@
 import sys
 import argparse
 
+
 parser = argparse.ArgumentParser()
 parser.add_argument('package')
 args = parser.parse_args()
 
+
 resources = sys.stdin.read()
+
+
+PYPI_METADATA = {
+    "networkx": {
+        "2.8.0": {
+            "url": "https://files.pythonhosted.org/packages/3f/5e/5e9ae193c6384bd47aae5bc9bd2c48db7115f483b0ff9fef7d263e3dbb09/networkx-2.8.tar.gz",
+            "sha256": "4a52cf66aed221955420e11b3e2e05ca44196b4829aab9576d4d439212b0a14f",
+        },
+    },
+    "cryptography": {
+        "38.0.4": {
+            "url": "https://files.pythonhosted.org/packages/e3/3f/41186b1f2fd86a542d399175f6b8e43f82cd4dfa51235a0b030a042b811a/cryptography-38.0.4.tar.gz",
+            "sha256": "175c1a818b87c9ac80bb7377f5520b7f31b3ef2a0004e2420319beadedb67290",
+        },
+    },
+    "redshift-connector": {
+        "2.0.913": {
+            "url": "https://files.pythonhosted.org/packages/63/86/fb94423bc8c385fdce1bfe2afe720bf415d9df56e137e4f321e13844c498/redshift_connector-2.0.913-py3-none-any.whl",
+            "sha256": "bd70395c5b7ec9fcae9565daff6bcb88c7d3ea6182dafba2bac6138f68d00582",
+        },
+    },
+}
+
+
+def pinned_package_override(package: str, version: str) -> str:
+    url = PYPI_METADATA[package][version]["url"]
+    sha256 = PYPI_METADATA[package][version]["sha256"]
+    pinned = f'  resource "{package}" do # pinned to {version}\n    url "{url}"\n    sha256 "{sha256}"\n  end'
+    return pinned
+
 
 resource_list = resources.split("\n\n")
 to_return = []
 for resource in resource_list:
+
     # we need to pin networkx and cryptography packages due to dependency bugs
+    # we need to pin redshift_connector because they are not publishing sdists, only wheels
     # this finds those dependencies and replaces them with the stable versions
-    if 'networkx' in resource:
-        networkx = '  resource "networkx" do # pinned to 2.8.0\n    url "https://files.pythonhosted.org/packages/3f/5e/5e9ae193c6384bd47aae5bc9bd2c48db7115f483b0ff9fef7d263e3dbb09/networkx-2.8.tar.gz"\n    sha256 "4a52cf66aed221955420e11b3e2e05ca44196b4829aab9576d4d439212b0a14f"\n  end'
-        to_return.append(networkx)
-    elif 'cryptography' in resource:
-        cryptography = '  resource "cryptography" do # pinned to 38.0.4\n    url "https://files.pythonhosted.org/packages/e3/3f/41186b1f2fd86a542d399175f6b8e43f82cd4dfa51235a0b030a042b811a/cryptography-38.0.4.tar.gz"\n    sha256 "175c1a818b87c9ac80bb7377f5520b7f31b3ef2a0004e2420319beadedb67290"\n  end'
-        to_return.append(cryptography)
-    # this adds the rest of the dependencies except the actual adapter
-    # we don't want the adapter in the dependency list
-    elif args.package not in resource:
+    if "networkx" in resource:
+        to_return.append(pinned_package_override("networkx", "2.8.0"))
+    elif "cryptography" in resource:
+        to_return.append(pinned_package_override("cryptography", "38.0.4"))
+    elif "redshift-connector" in resource:
+        to_return.append(pinned_package_override("redshift-connector", "2.0.913"))
+
+    # don't include the adapter in the dependency list
+    elif args.package in resource:
+        pass
+
+    # add the rest of the dependencies as is
+    else:
         to_return.append(resource)
+
+
 print("\n\n".join(to_return))


### PR DESCRIPTION
### Description

Add url and sha for redshift-connector using the existing override used by cryptography and networkx.

Streamline the overrides to be config driven in case we need to do this again.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [ ] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
