### PR TITLE
Configure dependabot for GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    rebase-strategy: "disabled"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ build/
 images/
 !images/.gitkeep
 env*/
+
+# pycharm
+.idea

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+from setuptools import setup
+
+setup(
+    name="homebrew-dbt",
+    author="dbt Labs",
+    author_email="info@dbtlabs.com",
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Operating System :: POSIX :: Linux",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+    ],
+    python_requires=">=3.8",
+)


### PR DESCRIPTION
### Description

Configure dependabot for GHA and add a basic `setup.py`. Despite this repo containing javascript, Ruby, and Python, there are no dependencies, hence we don't need dependabot for those languages. The code that is actually run is python code, hence that was chosen as the "primary language". As such, a `setup.py` was also added.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR
