### PR TITLE
Update action to use newer version of python

### DIFF
--- a/.github/workflows/formula.yml
+++ b/.github/workflows/formula.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Get python package info
         id: package-info
-        uses: dbt-labs/actions/py-package-info@v1
+        uses: dbt-labs/actions/py-package-info@main
         with:
           package: ${{ github.event.inputs.dbt-package }}
           version: ${{ steps.semver.outputs.version }}


### PR DESCRIPTION
### Description

We need to point to a newer version of `py-package-info` to use a newer version of python.

### Checklist

- [x] I have signed the [CLA](https://docs.getdbt.com/docs/contributor-license-agreements)
- [x] I have run this code in development and it appears to resolve the stated issue
- [x] This PR includes tests, or tests are not required/relevant for this PR